### PR TITLE
Revert image tag to 0.0.3

### DIFF
--- a/packages/installCatalog.sh
+++ b/packages/installCatalog.sh
@@ -24,7 +24,7 @@ DOCKER="$4"
 # If docker is not provided, set to default version.
 if [ -z "$4" ]
   then
-    DOCKER="ibmfunctions/wskdeploy:0.0.4"
+    DOCKER="ibmfunctions/wskdeploy:0.0.3"
 fi
 
 # If the auth key file exists, read the key in the file. Otherwise, take the


### PR DESCRIPTION
Reverting this to 0.0.3: the default image tag has been changed to `0.0.4` in https://github.com/ibm-functions/package-deploy/pull/4, but the image didn't change.